### PR TITLE
Fix unknown types

### DIFF
--- a/lib/metaphone_ptbr.c
+++ b/lib/metaphone_ptbr.c
@@ -34,7 +34,7 @@ Metastring *metastring_create(char *init_str) {
   return s;
 }
 
-void metastring_destroy(Metastring *s, ushort preserve_string) {
+void metastring_destroy(Metastring *s, short preserve_string) {
   if (s == NULL) {
     return;
   }
@@ -150,13 +150,13 @@ wchar_t *make_upper_clean(wchar_t *i) {
   return s;
 }
 
-wchar_t get_at(wchar_t *s, uint pos) {
+wchar_t get_at(wchar_t *s, int pos) {
   if ((pos >= wcslen(s)))
     return '\0';
   return ((wchar_t) * (s + pos));
 }
 
-wchar_t get_simplified_at(wchar_t *s, uint pos) {
+wchar_t get_simplified_at(wchar_t *s, int pos) {
   if ((pos >= wcslen(s)))
     return '\0';
   return ((wchar_t) * (s + pos));

--- a/lib/metaphone_ptbr.c
+++ b/lib/metaphone_ptbr.c
@@ -150,13 +150,13 @@ wchar_t *make_upper_clean(wchar_t *i) {
   return s;
 }
 
-wchar_t get_at(wchar_t *s, int pos) {
+wchar_t get_at(wchar_t *s, long pos) {
   if ((pos >= wcslen(s)))
     return '\0';
   return ((wchar_t) * (s + pos));
 }
 
-wchar_t get_simplified_at(wchar_t *s, int pos) {
+wchar_t get_simplified_at(wchar_t *s, long pos) {
   if ((pos >= wcslen(s)))
     return '\0';
   return ((wchar_t) * (s + pos));

--- a/lib/metaphone_ptbr.c
+++ b/lib/metaphone_ptbr.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <wchar.h>
-#include <types.h>
+#include <sys/types.h>
 #include <wctype.h>
 
 #include "metaphone_ptbr.h"

--- a/lib/metaphone_ptbr.c
+++ b/lib/metaphone_ptbr.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <wchar.h>
+#include <types.h>
 #include <wctype.h>
 
 #include "metaphone_ptbr.h"
@@ -34,7 +35,7 @@ Metastring *metastring_create(char *init_str) {
   return s;
 }
 
-void metastring_destroy(Metastring *s, short preserve_string) {
+void metastring_destroy(Metastring *s, ushort preserve_string) {
   if (s == NULL) {
     return;
   }
@@ -150,13 +151,13 @@ wchar_t *make_upper_clean(wchar_t *i) {
   return s;
 }
 
-wchar_t get_at(wchar_t *s, long pos) {
+wchar_t get_at(wchar_t *s, uint pos) {
   if ((pos >= wcslen(s)))
     return '\0';
   return ((wchar_t) * (s + pos));
 }
 
-wchar_t get_simplified_at(wchar_t *s, long pos) {
+wchar_t get_simplified_at(wchar_t *s, uint pos) {
   if ((pos >= wcslen(s)))
     return '\0';
   return ((wchar_t) * (s + pos));


### PR DESCRIPTION
Fix some errors when compiling on OS X:

```
../lib/metaphone_ptbr.c:37:40: error: unknown type name 'ushort'; did you mean 'short'?
void metastring_destroy(Metastring *s, ushort preserve_string) {
                                       ^~~~~~
                                       short
../lib/metaphone_ptbr.c:153:28: error: unknown type name 'uint'; did you mean 'int'?
wchar_t get_at(wchar_t *s, uint pos) {
                           ^~~~
                           int

../lib/metaphone_ptbr.c:159:39: error: unknown type name 'uint'; did you mean 'int'?
wchar_t get_simplified_at(wchar_t *s, uint pos) {
                                      ^~~~
                                      int
```
